### PR TITLE
Downgrade Tomcat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,6 @@ COPY aggregator_pom.xml /usr/src/app
 RUN mvn -f /usr/src/app/aggregator_pom.xml install -Dmaven.test.skip=true
 RUN mvn -f /usr/src/app/pom.xml clean package -Dmaven.test.skip=true
 
-FROM tomcat:jdk8-openjdk
+FROM tomcat:9
 COPY --from=build /usr/src/app/target/iis-sandbox.war $CATALINA_HOME/webapps
 EXPOSE 8080


### PR DESCRIPTION
After composing the Docker container using `docker compose up -d`, I receive the following jakarta.servlet.ServletException 500 Error while accessing http://localhost:8081/iis-sandbox/ in the browser:

```
Type Exception Report

Message Class [org.immregistries.iis.kernal.servlet.HomeServlet] is not a Servlet

Description The server encountered an unexpected condition that prevented it from fulfilling the request.

Exception

jakarta.servlet.ServletException: Class [org.immregistries.iis.kernal.servlet.HomeServlet] is not a Servlet
	org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:541)
	org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:92)
	org.apache.catalina.valves.AbstractAccessLogValve.invoke(AbstractAccessLogValve.java:690)
	org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:353)
	org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:382)
	org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:65)
	org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:872)
	org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1695)
	org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)
	org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1191)
	org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:659)
	org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
	java.lang.Thread.run(Thread.java:748)
Root Cause

java.lang.ClassCastException: org.immregistries.iis.kernal.servlet.HomeServlet cannot be cast to jakarta.servlet.Servlet
	org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:541)
	org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:92)
	org.apache.catalina.valves.AbstractAccessLogValve.invoke(AbstractAccessLogValve.java:690)
	org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:353)
	org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:382)
	org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:65)
	org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:872)
	org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1695)
	org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)
	org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1191)
	org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:659)
	org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
	java.lang.Thread.run(Thread.java:748)
```

According to https://stackoverflow.com/questions/66741683/dispatcherservlet-cannot-be-cast-to-class-jakarta-servlet-servlet-classcastexce, there are issues with the Jakarta interface being used and the latest version of Tomcat. 

This pull request downgrades Tomcat to version 9, in order to avoid this exception being thrown.

